### PR TITLE
Update links to point to the new repo

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -10,10 +10,10 @@ The HTTP API is only one of the specifications that makes the package manager He
 
 Below is a list of related specifications:
 
-  * [Endpoints](https://github.com/hexpm/hex_web/blob/master/specifications/endpoints.md)
-  * [Tarball format](https://github.com/hexpm/hex_web/blob/master/specifications/package_tarball.md)
-  * [Registry format](https://github.com/hexpm/hex_web/blob/master/specifications/registry.md)
-  * [Package metadata](https://github.com/hexpm/hex_web/blob/master/specifications/package_metadata.md)
+  * [Endpoints](https://github.com/hexpm/specifications/blob/master/endpoints.md)
+  * [Tarball format](https://github.com/hexpm/specifications/blob/master/package_tarball.md)
+  * [Registry format](https://github.com/hexpm/specifications/blob/master/registry.md)
+  * [Package metadata](https://github.com/hexpm/specifications/blob/master/package_metadata.md)
   * [Semantic Versioning](http://semver.org/)
 
 ### Media types

--- a/endpoints.md
+++ b/endpoints.md
@@ -4,12 +4,12 @@ The Hex API has two endpoints: an HTTP API, which is used for all administrative
 
 ### HTTP API
 
-See [apiary.apib](https://github.com/hexpm/hex_web/blob/master/apiary.apib) file at the root of this repository.
+See [apiary.apib](https://github.com/hexpm/specifications/blob/master/apiary.apib) file at the root of this repository.
 
 ### CDN
 
-  * /registry.ets.gz - [Registry](https://github.com/hexpm/hex_web/blob/master/specifications/registry.md)
-  * /tarballs/PACKAGE-VERSION.tar - [Package tarball](https://github.com/hexpm/hex_web/blob/master/specifications/package_tarball.md)
+  * /registry.ets.gz - [Registry](https://github.com/hexpm/specifications/blob/master/registry.md)
+  * /tarballs/PACKAGE-VERSION.tar - [Package tarball](https://github.com/hexpm/specifications/blob/master/package_tarball.md)
 
 ### Hex.pm endpoints
 

--- a/package_tarball.md
+++ b/package_tarball.md
@@ -8,7 +8,7 @@ The package tarball contains the following files:
 
   * metadata.config
 
-    Erlang term file, see [Package metadata](https://github.com/hexpm/hex_web/blob/master/specifications/package_metadata.md).
+    Erlang term file, see [Package metadata](https://github.com/hexpm/specifications/blob/master/package_metadata.md).
 
   * contents.tar.gz
 

--- a/registry.md
+++ b/registry.md
@@ -22,7 +22,7 @@ Below is the layout of the table.
         - Requirement: binary Elixir [version requirement][]
         - Optional: boolean, true if it's an optional dependency
         - App: binary, OTP application name
-    - Checksum: binary hex encoded sha256 checksum of package, see [Package Tarball](https://github.com/hexpm/hex_web/blob/master/specifications/package_tarball.md)
+    - Checksum: binary hex encoded sha256 checksum of package, see [Package Tarball](https://github.com/hexpm/specifications/blob/master/package_tarball.md)
     - BuildTools: list of build tool names as binary strings
 
 [`ets:tab2file/1`]: http://www.erlang.org/doc/man/ets.html#tab2file-2


### PR DESCRIPTION
Looks like some of the urls after the move to a separate repo where missed to be updated.