### PR TITLE
Remove mentions of contributors, use maintainers

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -296,7 +296,7 @@ This collection is paginated.
 + Attributes
     + `name` (string, required) - Package name
     + `meta` (object, required) - Package metadata
-        + `contributors` (array[string], required) - Package maintainers (migrating to rename attribute to `maintainers` both values are valid)
+        + `maintainers` (array[string], required) - Package maintainers
         + `links` (object, required) - Links related to the package, key is the link name, value is the URL
         + `licenses` (array[string], required) - Licenses that apply to the package
         + `description` (string, required) - Package description, recommended to be a single paragraph

--- a/package_metadata.md
+++ b/package_metadata.md
@@ -39,15 +39,11 @@ All keys are strings.
 
   + `licenses (list(string))`
 
-    The library's licenses
+    The package's licenses
 
-  + `contributors (list(string))`
+  + `maintainers (list(string))`
 
-    The library's maintainers, can be a list of names and/or emails
-
-    NOTE: This field is deprecated and will change name to `maintainers`, new packages
-    should use `maintainers` but old packages will use `contributors` until the conversion
-    happens
+    The package's maintainers, can be a list of names and/or emails
 
   + `links (kvlist(string => string))`
 


### PR DESCRIPTION
Since HexWeb dropped contributors a while ago, I think it should be safe to update specs.