### PR TITLE
Add purl specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   * [New registry format](https://github.com/hexpm/specifications/blob/master/registry-v2.md)
   * [Tarball format](https://github.com/hexpm/specifications/blob/master/package_tarball.md)
   * [Package metadata](https://github.com/hexpm/specifications/blob/master/package_metadata.md)
+  * [purl (Package URL) format](https://github.com/hexpm/specifications/blob/master/package-url.md)
 
 ## Repositories and mirrors
 

--- a/package-url.md
+++ b/package-url.md
@@ -18,7 +18,7 @@ written in/for Erlang, Elixir or any other BEAM language.
 ## Definition
 
 * The 'type' is "hex"
-* The default repository is https://hex.pm
+* The default repository is https://repo.hex.pm
 * The 'namespace' is optional; it may be used to specify the organization for
   private packages on hex.pm; it is not case sensitive and must be lowercased.
 * The 'name' is the package name; it is not case sensitive and must be lowercased

--- a/package-url.md
+++ b/package-url.md
@@ -20,9 +20,15 @@ written in/for Erlang, Elixir or any other BEAM language.
 * The 'type' is "hex"
 * The default repository is https://hex.pm
 * The 'namespace' is optional; it may be used to specify the organization for
-  private packages on hex.pm
-* The 'name' is the package name
+  private packages on hex.pm; it is not case sensitive and must be lowercased.
+* The 'name' is the package name; it is not case sensitive and must be lowercased
 * The 'version' is the package version
+* Optional qualifiers:
+  * 'repository_url' - used to select a non-default repository; it must contain
+     the full base URL for the repository, not the short name that's used
+     locally to select it; run 'mix help hex.repo' for more information on
+     setting repository URLs
+  * 'checksum' - as per purl specification
 
 ## Examples
 

--- a/package-url.md
+++ b/package-url.md
@@ -1,0 +1,42 @@
+# purl format for Hex
+
+## Introduction
+
+[purl or Package URL](https://github.com/package-url/purl-spec) is a
+specification for identifying and locating software packages. It may be used
+to uniquely identify a package or package version in a software
+bill-of-materials (SBOM) or vulnerability report, or to locate the package in a
+repository, e.g. to check for updates.
+
+In particular, the [CycloneDX](https://cyclonedx.org) SBOM specification
+uses purl to identify components.
+
+This document formalizes the purl format for packages hosted on hex.pm or
+compatible repositories. Like Hex itself, it applies equally to packages
+written in/for Erlang, Elixir or any other BEAM language.
+
+## Definition
+
+* The 'type' is "hex"
+* The default repository is https://hex.pm
+* The 'namespace' is optional; it may be used to specify the organization for
+  private packages on hex.pm
+* The 'name' is the package name
+* The 'version' is the package version
+
+## Examples
+
+The public "jason" package at version 1.1.2 would be identified by the
+following purl:
+
+    pkg:hex/jason@1.1.2
+
+Version 2.3.4 of a package named "foo", published under the "acme" organization
+on hex.pm would be identified by the following purl:
+
+    pkg:hex/acme/foo@2.3.4
+
+Other examples include:
+
+    pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com
+    pkg:hex/jason@1.1.2?checksum=sha256:fdf843bca858203ae1de16da2ee206f53416bbda5dc8c9e78f43243de4bc3afe


### PR DESCRIPTION
Would you be interested in formally defining and documenting the purl format for Hex packages? I believe this could help with SBOM tooling and vulnerability tracking.