### PR TITLE
Document what the tarball version should be

### DIFF
--- a/package_tarball.md
+++ b/package_tarball.md
@@ -4,7 +4,7 @@ The package tarball contains the following files:
 
   * VERSION
 
-    The tarball version as a single ASCII integer.
+    The tarball version as a single ASCII integer. The current tarball version is 3.
 
   * metadata.config
 


### PR DESCRIPTION
I had to read hex_core's source code to find this- I mistakenly thought this was the version of the package being uploaded.