### PR TITLE
fix: Fetch a release uses `retirement`. Fetch a user returns proper JSON.

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -174,7 +174,7 @@ API clients are required to include a text with a link to the [Hex Terms of Serv
 
             {
               "username": "ericmj",
-              "email": "ericmj@mail.com"
+              "email": "ericmj@mail.com",
               "inserted_at": "2015-04-05T01:21:49Z",
               "updated_at": "2015-04-05T01:21:49Z",
               "url": "https://hex.pm/api/users/ericmj"

--- a/apiary.apib
+++ b/apiary.apib
@@ -209,7 +209,7 @@ API clients are required to include a text with a link to the [Hex Terms of Serv
 
             {
               "username": "ericmj",
-              "email": "ericmj@mail.com"
+              "email": "ericmj@mail.com",
               "inserted_at": "2015-04-05T01:21:49Z",
               "updated_at": "2015-04-05T01:21:49Z",
               "url": "https://hex.pm/api/users/ericmj"

--- a/apiary.apib
+++ b/apiary.apib
@@ -489,7 +489,7 @@ Also available under /repos/{repository} for packages belonging to a specific re
             + `requirement` (string, required) - [Version requirement](http://elixir-lang.org/docs/stable/elixir/Version.html) on dependency
             + `optional` (boolean, required) - An optional dependency only has to be satisfied if a package higher up the chain also requires it
             + `app` (string, required) - OTP application name, usually the dependency name but can differ
-    + `retired` (object, optional) - Retirement status, if not set the release is not retired
+    + `retirement` (object, optional) - Retirement status, if not set the release is not retired
         + `reason` (enum[string], required) - Reason for retirement
             + Members
                 + `other`


### PR DESCRIPTION
## Issue 1 of 2: Fetch a Release labels `retirement` key incorrectly as `retired`

The discrepancy is reproducible using `curl` (`jq` for formatting json).


<summary>Test 1: Plug v1.13.1 is retired</summary>
<details>

 Its JSON key for that retirement is `retirement` not `retired`

```bash
curl https://hex.pm/api/packages/plug/releases/1.13.1 | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1064  100  1064    0     0   2558      0 --:--:-- --:--:-- --:--:--  2557
{
  "meta": {
    "elixir": "~> 1.7",
    "app": "plug",
    "build_tools": [
      "mix"
    ]
  },
  "version": "1.13.1",
  "checksum": "dc20c180ca0d30cffd5e297e10efaa48d0b05541d813573fb17ccb6123d84246",
  "url": "https://hex.pm/api/packages/plug/releases/1.13.1",
  "has_docs": true,
  "inserted_at": "2022-02-03T22:08:21.735313Z",
  "updated_at": "2022-02-12T11:46:15.715331Z",
  "retirement": {
    "message": "Package has an incompatible breaking change",
    "reason": "invalid"
  },
  "publisher": {
    "url": "https://hex.pm/api/users/josevalim",
    "email": "jose.valim@gmail.com",
    "username": "josevalim"
  },
  "downloads": 6872,
  "requirements": {
    "mime": {
      "optional": false,
      "app": "mime",
      "requirement": "~> 1.0 or ~> 2.0"
    },
    "plug_crypto": {
      "optional": false,
      "app": "plug_crypto",
      "requirement": "~> 1.1.1 or ~> 1.2"
    },
    "telemetry": {
      "optional": false,
      "app": "telemetry",
      "requirement": "~> 0.4.3 or ~> 1.0"
    }
  },
  "docs_html_url": "https://hexdocs.pm/plug/1.13.1/",
  "package_url": "https://hex.pm/api/packages/plug",
  "configs": {
    "erlang.mk": "dep_plug = hex 1.13.1",
    "mix.exs": "{:plug, \"~> 1.13\"}",
    "rebar.config": "{plug, \"1.13.1\"}"
  },
  "html_url": "https://hex.pm/packages/plug/1.13.1"
}
```
</details>

<summary>Test 2: ex_ftp v0.9.2 is retired very recently.</summary>

<details>
It's the same, `retirement`, not `retired`.

```
➜  specifications git:(main) ✗ curl https://hex.pm/api/packages/ex_ftp/releases/0.9.2 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1438  100  1438    0     0   3356      0 --:--:-- --:--:-- --:--:--  3359
{
  "meta": {
    "elixir": "~> 1.18",
    "app": "ex_ftp",
    "build_tools": [
      "mix"
    ]
  },
  "version": "0.9.2",
  "checksum": "8a081954bf27615b1175bbdb594aa058dafbccdf6bc452a16798de07e3d11c2b",
  "url": "https://hex.pm/api/packages/ex_ftp/releases/0.9.2",
  "has_docs": true,
  "inserted_at": "2025-05-21T02:45:51.394759Z",
  "updated_at": "2025-05-21T19:30:48.781725Z",
  "retirement": {
    "message": "pre-release",
    "reason": "deprecated"
  },
  "publisher": {
    "url": "https://hex.pm/api/users/camatcode",
    "email": "cam.cook.codes@gmail.com",
    "username": "camatcode"
  },
  "downloads": 15,
  "requirements": {
    "cachex": {
      "optional": false,
      "app": "cachex",
      "requirement": "~> 4.0"
    },
    "configparser_ex": {
      "optional": false,
      "app": "configparser_ex",
      "requirement": "~> 4.0"
    },
    "ex_aws": {
      "optional": false,
      "app": "ex_aws",
      "requirement": "~> 2.0"
    },
    "ex_aws_s3": {
      "optional": false,
      "app": "ex_aws_s3",
      "requirement": "~> 2.0"
    },
    "hackney": {
      "optional": false,
      "app": "hackney",
      "requirement": "~> 1.9"
    },
    "poison": {
      "optional": false,
      "app": "poison",
      "requirement": "~> 5.0"
    },
    "proper_case": {
      "optional": false,
      "app": "proper_case",
      "requirement": "~> 1.3"
    },
    "req": {
      "optional": false,
      "app": "req",
      "requirement": "~> 0.5.10"
    },
    "sweet_xml": {
      "optional": false,
      "app": "sweet_xml",
      "requirement": "~> 0.7"
    }
  },
  "docs_html_url": "https://hexdocs.pm/ex_ftp/0.9.2/",
  "package_url": "https://hex.pm/api/packages/ex_ftp",
  "configs": {
    "erlang.mk": "dep_ex_ftp = hex 0.9.2",
    "mix.exs": "{:ex_ftp, \"~> 0.9.2\"}",
    "rebar.config": "{ex_ftp, \"0.9.2\"}"
  },
  "html_url": "https://hex.pm/packages/ex_ftp/0.9.2"
}
```
</details>
----


## Issue 2 of 2: Fetch a User is missing a comma (resulting in bad JSON)

The example in the apiary (and thus the mock server) returns bad JSON for fetch a user (missing comma after `email`)

```json
{
  "username": "ericmj",
  "email": "ericmj@mail.com" 
  "inserted_at": "2015-04-05T01:21:49Z",
  "updated_at": "2015-04-05T01:21:49Z",
  "url": "https://hex.pm/api/users/ericmj"
}
```


Resolves https://github.com/hexpm/specifications/issues/41

