### PR TITLE
Add published_at field to Release message

### DIFF
--- a/registry/package.proto
+++ b/registry/package.proto
@@ -27,6 +27,9 @@ message Release {
   optional bytes outer_checksum = 5;
   // Indexes into Package.advisories for advisories affecting this release
   repeated uint32 advisory_indexes = 6;
+  // Release published timestamp. Optional for backwards compatibility —
+  // clients treat absence as "no information".
+  optional Timestamp published_at = 7;
 }
 
 message RetirementStatus {
@@ -77,4 +80,11 @@ message Dependency {
   optional string app = 4;
   // If set, the repository where the dependency is located
   optional string repository = 5;
+}
+
+// Based on google.protobuf.Timestamp
+// https://github.com/protocolbuffers/protobuf/blob/v3.15.8/src/google/protobuf/timestamp.proto#L136:L147
+message Timestamp {
+  required int64 seconds = 1;
+  required int32 nanos = 2;
 }


### PR DESCRIPTION
Add an optional int64 published_at field to the Release message in package.proto, carrying the Unix epoch seconds at which the release was published to the repository.

The field is optional for backwards compatibility; absence means "no information available". Clients can use it to compute release age and apply policies such as a configurable release-age cooldown during dependency resolution to mitigate supply-chain attacks.

Follow up to https://github.com/hexpm/hex_core/pull/187.