### PR TITLE
Fix Hex purl specification link

### DIFF
--- a/package-url.md
+++ b/package-url.md
@@ -2,4 +2,4 @@
 
 This specification has been standardized and moved to the official purl repository:
 
-https://github.com/package-url/purl-spec/blob/main/types-doc/hex-definition.md
+https://github.com/package-url/purl-spec/blob/main/docs/types/definitions/hex-definition.md


### PR DESCRIPTION
Updates the Hex package URL specification link after the upstream document moved from `types-doc` to `docs/types/definitions`, so it no longer returns 404.

The replacement URL was verified to return HTTP 200.

Fixes #69.
